### PR TITLE
fix title icons for light detail

### DIFF
--- a/esphomeRemote/esphomeRemote.h
+++ b/esphomeRemote/esphomeRemote.h
@@ -485,6 +485,26 @@ void drawLightSlider(int xPos, int yPos, bool slider_selection, bool slider_sele
   }
 }
 
+void drawTitleIcon(std::vector<std::shared_ptr<MenuTitleBase>> menuTitles, int i, int menuState, int yPos) {
+  switch (menuTitles[i]->titleState) {
+    case NoMenuTitleState:
+      break;
+    case OffMenuTitleState:
+    case OnMenuTitleState:
+      drawSwitch(menuTitles[i]->titleState == OnMenuTitleState, yPos);
+      break;
+    case ArrowMenuTitleState:
+      if (menuState == i) {
+        drawArrow(yPos, menuTitles.size());
+      }
+      break;
+    case GroupedMenuTitleState:
+      bool extend = i < menuTitles.size() - 1 && menuTitles[i + 1]->titleState == GroupedMenuTitleState;
+      drawGroupedBar(yPos, extend);
+      break;
+  }
+}
+
 void drawMenu(std::vector<std::shared_ptr<MenuTitleBase>> menuTitles) {
   activeMenuTitleCount = menuTitles.size();
   if (menuTitles.size() == 0) {
@@ -500,28 +520,11 @@ void drawMenu(std::vector<std::shared_ptr<MenuTitleBase>> menuTitles) {
       break;
     }
     switch (menuTitles[i]->titleType) {
-      case BaseMenuTitleType: {
+      case BaseMenuTitleType:
         drawTitle(menuState, i, menuTitles[i]->friendlyName, yPos, menuTitles[i]->indentLine());
-        switch (menuTitles[i]->titleState) {
-          case NoMenuTitleState:
-            break;
-          case OffMenuTitleState:
-          case OnMenuTitleState:
-            drawSwitch(menuTitles[i]->titleState == OnMenuTitleState, yPos);
-            break;
-          case ArrowMenuTitleState:
-            if (menuState == i) {
-              drawArrow(yPos, menuTitles.size());
-            }
-            break;
-          case GroupedMenuTitleState:
-            bool extend = i < menuTitles.size() - 1 && menuTitles[i + 1]->titleState == GroupedMenuTitleState;
-            drawGroupedBar(yPos, extend);
-            break;
-        }
+        drawTitleIcon(menuTitles, i, menuState, yPos);
         yPos += id(medium_font_size) + id(margin_size);
         break;
-      }
       case LightMenuTitleType:
         // TODO: this breaks the scrolling if there are more items then can fit on the screen
         // sliderExtra doesn't solve it. Figure out whats missing to get it to work
@@ -531,6 +534,7 @@ void drawMenu(std::vector<std::shared_ptr<MenuTitleBase>> menuTitles) {
           auto item = std::static_pointer_cast<MenuTitleSlider>(mt);
           drawLightSlider(id(slider_margin_size), yPos, menuState == i, menuState == i && lightDetailSelected,
                           item->slider_width, mt->friendlyName, item->title_extra);
+          drawTitleIcon(menuTitles, i, menuState, yPos);
           sliderExtra += 2;
 
           yPos += (id(medium_font_size) + id(margin_size)) * 2;
@@ -542,6 +546,7 @@ void drawMenu(std::vector<std::shared_ptr<MenuTitleBase>> menuTitles) {
           drawTitle(menuState, i, menuTitles[i]->friendlyName, yPos, menuTitles[i]->indentLine());
           int length = playerTitle->friendlyName.length() + (playerTitle->indentLine() ? 2 : 0);
           drawTitleImage(length, yPos, playerTitle->playerState, menuState == i);
+          drawTitleIcon(menuTitles, i, menuState, yPos);
           yPos += id(medium_font_size) + id(margin_size);
         }
         break;

--- a/esphomeRemote/esphomeRemoteLight.h
+++ b/esphomeRemote/esphomeRemoteLight.h
@@ -161,7 +161,7 @@ class LightService : public CustomAPIDevice, public Component {
       } else {
       }
       out.push_back(std::make_shared<MenuTitleSlider>("Brightness", s.c_str(), entityId,
-                                                      onState ? OnMenuTitleState : OffMenuTitleState,
+                                                      NoMenuTitleState,
                                                       (int) (localBrightness * slider_factor)));
     }
 
@@ -178,7 +178,7 @@ class LightService : public CustomAPIDevice, public Component {
       int sliderValue = static_cast<int>(factor * static_cast<float>(localColorTempTransformed));
 
       out.push_back(std::make_shared<MenuTitleSlider>("Temperature", s.c_str(), entityId,
-                                                      onState ? OnMenuTitleState : OffMenuTitleState, sliderValue));
+                                                      NoMenuTitleState, sliderValue));
     }
     return out;
   }


### PR DESCRIPTION
we have to call the code in `drawTitleIcon` after we call `drawTitle`. `drawTitle` draws the color background and the text so it will cover up the `drawTitleIcon`. I also changed the brightness and temperature rows so they have no title icon because theyre a slider instead of on/off